### PR TITLE
Guarding calls to possibly nil cache_store.

### DIFF
--- a/lib/cachable.rb
+++ b/lib/cachable.rb
@@ -64,13 +64,13 @@ module Cachable
       alias_method_chain :get, :cache
 
       def put_with_cache(path, body = '', headers = {})
-        cache_store.delete(cache_key(path))
+        cache_store.try(:delete, cache_key(path))
         put_without_cache(path, body, headers)
       end
       alias_method_chain :put, :cache
       
       def delete_with_cache(path, headers = {})
-        cache_store.delete(cache_key(path))
+        cache_store.try(:delete, cache_key(path))
         delete_without_cache(path, headers)
       end
       alias_method_chain :delete, :cache


### PR DESCRIPTION
Here's an improvement on the pull request from @madsheep.  I'm protecting both put and delete.  I ran into this while trying to use another ActiveResource gem with caching off.  When caching is off cache_store is always going to be nil.
