### PR TITLE
Change activeresource dependency to '~>3.0' to work with 3.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,22 +2,26 @@ PATH
   remote: .
   specs:
     highrise (3.0.0)
-      activeresource (~> 3.0.0)
+      activeresource (~> 3.0)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    activemodel (3.0.3)
-      activesupport (= 3.0.3)
-      builder (~> 2.1.2)
-      i18n (~> 0.4)
-    activeresource (3.0.3)
-      activemodel (= 3.0.3)
-      activesupport (= 3.0.3)
-    activesupport (3.0.3)
-    builder (2.1.2)
+    activemodel (3.1.0)
+      activesupport (= 3.1.0)
+      bcrypt-ruby (~> 3.0.0)
+      builder (~> 3.0.0)
+      i18n (~> 0.6)
+    activeresource (3.1.0)
+      activemodel (= 3.1.0)
+      activesupport (= 3.1.0)
+    activesupport (3.1.0)
+      multi_json (~> 1.0)
+    bcrypt-ruby (3.0.0)
+    builder (3.0.0)
     diff-lcs (1.1.2)
-    i18n (0.5.0)
+    i18n (0.6.0)
+    multi_json (1.0.3)
     rake (0.8.7)
     rspec (2.0.1)
       rspec-core (~> 2.0.1)

--- a/highrise.gemspec
+++ b/highrise.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
 
   s.required_rubygems_version = ">= 1.3.6"
-  s.add_dependency "activeresource", "~>3.0.0"
+  s.add_dependency "activeresource", "~>3.0"
   s.add_development_dependency "rspec", "~>2.0.1"
   s.add_development_dependency "rake", "=0.8.7"
 


### PR DESCRIPTION
Small change to dependency version to work with activeresource/rails 3.1. All specs still pass.
