### PR TITLE
"Illformed requirement" error fix?

### DIFF
--- a/highrise.gemspec
+++ b/highrise.gemspec
@@ -8,9 +8,9 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
 
   s.required_rubygems_version = ">= 1.3.6"
-  s.add_dependency "activeresource", "~>3.0"
-  s.add_development_dependency "rspec", "~>2.0.1"
-  s.add_development_dependency "rake", "=0.8.7"
+  s.add_dependency "activeresource", "~> 3.0"
+  s.add_development_dependency "rspec", "~> 2.0.1"
+  s.add_development_dependency "rake", "= 0.8.7"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features,examples}/*`.split("\n")


### PR DESCRIPTION
Hi,

I got the following error when I ran a bundle install:

```
Invalid gemspec in [/Users/ttt/.rvm/gems/ruby-1.9.2-p180@controlroom/specifications/highrise-3.0.1.gemspec]: Illformed requirement ["#<Syck::DefaultKey:0x000001043ca910> 0.8.7"]
```

and it appears the rubygems.org site has the error on: http://rubygems.org/gems/highrise

I'm thinking it's because of the missing spaces in the gemspec, which I've fixed and put in the commit. I'm not completely sure though, as I'm not very familiar with how gems and gemspecs work. But maybe you'll have more of an idea?

Cheers,
-Tak
