### PR TITLE
Paginate open and closed cases

### DIFF
--- a/lib/highrise/kase.rb
+++ b/lib/highrise/kase.rb
@@ -1,5 +1,7 @@
 module Highrise
   class Kase < Subject
+    include Pagination
+
     def open!
       update_attribute(:closed_at, nil)
     end
@@ -14,6 +16,14 @@ module Highrise
 
     def self.closed
       Kase.find(:all, :from => "/kases/closed.xml")
+    end
+
+    def self.all_open_across_pages
+      find_all_across_pages(:from => "/kases/open.xml")
+    end
+
+    def self.all_closed_across_pages
+      find_all_across_pages(:from => "/kases/closed.xml")
     end
   end
 end

--- a/spec/highrise/kase_spec.rb
+++ b/spec/highrise/kase_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe Highrise::Kase do
   it { should be_a_kind_of Highrise::Subject }
-  
+
+  it_should_behave_like "a paginated class"
+
   it "#close!" do
     mocked_now = Time.parse("Wed Jan 14 15:43:11 -0200 2009")
     Time.should_receive(:now).and_return(mocked_now)
@@ -13,5 +15,17 @@ describe Highrise::Kase do
   it "#open!" do
     subject.should_receive(:update_attribute).with(:closed_at, nil)
     subject.open!
+  end
+
+  it ".all_open_across_pages" do
+    subject.class.should_receive(:find).with(:all,{:from=>"/kases/open.xml",:params=>{:n=>0}}).and_return(["things"])
+    subject.class.should_receive(:find).with(:all,{:from=>"/kases/open.xml",:params=>{:n=>1}}).and_return([])
+    subject.class.all_open_across_pages.should == ["things"]
+  end
+
+  it ".all_closed_across_pages" do
+    subject.class.should_receive(:find).with(:all,{:from=>"/kases/closed.xml",:params=>{:n=>0}}).and_return(["things"])
+    subject.class.should_receive(:find).with(:all,{:from=>"/kases/closed.xml",:params=>{:n=>1}}).and_return([])
+    subject.class.all_closed_across_pages.should == ["things"]
   end
 end


### PR DESCRIPTION
Paginates `/kases/open.xml` and `/kases/closed.xml` using `Kase.all_open_across_pages` and `Kase.all_closed_across_pages`.
