### PR TITLE
Add support to OAuth token authorization in Highrise

### DIFF
--- a/lib/highrise/base.rb
+++ b/lib/highrise/base.rb
@@ -4,6 +4,25 @@ module Highrise
   class Base < ActiveResource::Base
     protected
 
+    class << self
+      # If headers are not defined in a given subclass, then obtain
+      # headers from the superclass.
+      # http://opensoul.org/blog/archives/2010/02/16/active-resource-in-practice/
+      def headers
+        if defined?(@headers)
+          @headers
+        elsif superclass != Object && superclass.headers
+          superclass.headers
+        else
+          @headers ||= {}
+        end
+      end
+
+      def oauth_token=(token)
+        headers['Authorization'] = "Bearer #{token}"
+      end
+    end
+
     # Fix for ActiveResource 3.1+ errors
     self.format = :xml
 

--- a/spec/highrise/base_spec.rb
+++ b/spec/highrise/base_spec.rb
@@ -45,4 +45,11 @@ describe Highrise::Base do
       expect { Highrise::Base.any_other_method }.to raise_error(NoMethodError)
     end
   end
+
+  describe "when using an oauth token" do
+    it ".oauth_token= writes a bearer authorization header" do
+      Highrise::Base.oauth_token = 'OAUTH_TOKEN'
+      Highrise::Base.headers['Authorization'].should == 'Bearer OAUTH_TOKEN'
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,8 +3,9 @@ Bundler.setup
 
 require File.join(File.dirname(__FILE__), '/../lib/highrise')
 
-Highrise::Base.user = ENV['HIGHRISE_USER'] || 'x'
-Highrise::Base.site = ENV['HIGHRISE_SITE'] || 'https://www.example.com'
+Highrise::Base.user        = ENV['HIGHRISE_USER']    || 'x'
+Highrise::Base.oauth_token = ENV['HIGHRISE_TOKEN']   || 'TOKEN'
+Highrise::Base.site        = ENV['HIGHRISE_SITE']    || 'https://www.example.com'
 
 require 'highrise/pagination_behavior'
 require 'highrise/searchable_behavior'


### PR DESCRIPTION
As `ActiveResource::Base` headers aren't inherited by subclasses, this patch was needed in order to support OAuth 2.0 token authorization with Highrise.

With this it becomes possible to use this gem for the scenario asked in #15, by doing:

```
$LOAD_PATH.unshift File.dirname(__FILE__) + '/../lib'
require 'highrise'
require 'pp'

Highrise::Base.site = 'https://example.highrisehq.com'
#Highrise::Base.user = 'xxx'
Highrise::Base.oauth_token = 'YOUR TOKEN HERE'

@tags = Highrise::Tag.find(:all)

pp @tags
```
