### PR TITLE
[WIP] Person#tags to avoid unnecessary requests

### DIFF
--- a/lib/highrise/person.rb
+++ b/lib/highrise/person.rb
@@ -3,23 +3,25 @@ module Highrise
     include Pagination
     include Taggable
     include Searchable
-    
+
+    attr :tags
+
     def company
       Company.find(company_id) if company_id
     end
-  
+
     def name
       "#{first_name rescue ''} #{last_name rescue ''}".strip
     end
-    
+
     def address
       contact_data.addresses.first
     end
-    
+
     def web_address
       contact_data.web_addresses.first
     end
-    
+
     def label
       'Party'
     end

--- a/lib/highrise/version.rb
+++ b/lib/highrise/version.rb
@@ -1,3 +1,3 @@
 module Highrise
-  VERSION = "3.1.1"
+  VERSION = "3.1.2"
 end


### PR DESCRIPTION
Please do not merge it yet, I must been speeding a little to much and it is not working as expected yet.

This is optimization patch that prevents sending additional request for tags.
Highrise responds with a list of tags while asking for a given person at: /people/:person_id.xml
