### PR TITLE
Person#tags prevents additional request

### DIFF
--- a/lib/highrise/person.rb
+++ b/lib/highrise/person.rb
@@ -3,23 +3,27 @@ module Highrise
     include Pagination
     include Taggable
     include Searchable
-    
+
+    def tags
+      self.attributes.has_key?("tags") ? self.attributes["tags"] : super
+    end
+
     def company
       Company.find(company_id) if company_id
     end
-  
+
     def name
       "#{first_name rescue ''} #{last_name rescue ''}".strip
     end
-    
+
     def address
       contact_data.addresses.first
     end
-    
+
     def web_address
       contact_data.web_addresses.first
     end
-    
+
     def label
       'Party'
     end

--- a/spec/highrise/person_spec.rb
+++ b/spec/highrise/person_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 
 describe Highrise::Person do
   subject { Highrise::Person.new(:id => 1) }
-  
+
   it { should be_a_kind_of Highrise::Subject }
 
   it_should_behave_like "a paginated class"
@@ -22,12 +22,26 @@ describe Highrise::Person do
       subject.company.should == "company"
     end
   end
-  
+
   it "#name" do
     subject.should_receive(:first_name).and_return("Marcos")
     subject.should_receive(:last_name).and_return("Tapajós     ")
     subject.name.should == "Marcos Tapajós"
   end
-  
+
+  describe "#tags" do
+    before(:each) do
+      (@tags = []).tap do
+        @tags << {'id' => "414578", 'name' => "cliente"}
+        @tags << {'id' => "414580", 'name' => "ged"}
+        @tags << {'id' => "414579", 'name' => "iepc"}
+      end
+      subject.attributes["tags"] = @tags
+    end
+    it {
+      subject.tags.should == @tags
+    }
+  end
+
   it { subject.label.should == 'Party' }
 end


### PR DESCRIPTION
Highrise Person resource respond with a list of tags so additional requests are redundant. 

Doc: 
https://github.com/37signals/highrise-api/blob/master/sections/people.md#get-person

In case there is not tags attribute on Highrise::Person we want to fetch them via taggalbe mixin.
