### PR TITLE
Added field to Person as an easy access method for subject-data

### DIFF
--- a/lib/highrise/person.rb
+++ b/lib/highrise/person.rb
@@ -27,5 +27,14 @@ module Highrise
     def label
       'Party'
     end
+    
+    def field(field_label)
+      custom_fields = attributes["subject_datas"] ||= []
+      field = custom_fields.detect { |field|
+        field.subject_field_label == field_label
+      }
+      field ? field.value : nil
+    end
+    
   end
 end

--- a/spec/highrise/person_spec.rb
+++ b/spec/highrise/person_spec.rb
@@ -42,6 +42,29 @@ describe Highrise::Person do
       subject.tags.should == @tags
     }
   end
+  
+  describe "Custom fields" do
+    
+    before (:each) do
+      @fruit_person = Highrise::Person.new({ :person => { 
+                        :id => 1, 
+                        :first_name => "John", 
+                        :last_name => "Doe",
+                        :subject_datas => [{
+                          :subject_field_label => "Fruit Banana",
+                          :value => "Yellow"
+                        }, {
+                          :subject_field_label => "Fruit Grape",
+                          :value => "Green"
+                        }]
+                      }
+                    })
+    end    
+    
+    it "Can get the value of a custom field via the field method" do
+      @fruit_person.field("Fruit Banana").should== "Yellow"
+    end
+  end
 
   it { subject.label.should == 'Party' }
 end


### PR DESCRIPTION
First pull requests in the Person class. This one is just a simple accessor for the custom-fields. The fixture (@fruit_person) is a bit too large considering the small method and spec in this case, but it will be reused in the upcoming pull requests (and it was a bit easier to include all of the data here).
