### PR TITLE
Changing a custom field when the field wasn't set before

### DIFF
--- a/lib/highrise/person.rb
+++ b/lib/highrise/person.rb
@@ -36,10 +36,20 @@ module Highrise
       field ? field.value : nil
     end
     
+    def new_subject_data(field, value)
+      Highrise::SubjectData.new(:subject_field_id => field.id, :subject_field_label => field.label, :value => value)
+    end
+    
     def set_field_value(field_label, new_value)
       custom_fields = attributes["subject_datas"] ||= []
       custom_fields.each { |field|
         return field.value = new_value if field.subject_field_label== field_label
+      }
+  
+      SubjectField.find(:all).each { |custom_field| 
+        if custom_field.label == field_label
+          return attributes["subject_datas"] << new_subject_data(custom_field, new_value)
+        end
       }
     end
         

--- a/spec/highrise/person_spec.rb
+++ b/spec/highrise/person_spec.rb
@@ -59,6 +59,8 @@ describe Highrise::Person do
                         }]
                       }
                     })
+      @subject_field_blueberry = Highrise::SubjectField.new ({:id => 1, :label => "Fruit Blueberry"})
+      @subject_field_papaya = Highrise::SubjectField.new ({:id => 2, :label => "Fruit Papaya"})
     end    
     
     it "Can get the value of a custom field via the field method" do
@@ -68,6 +70,13 @@ describe Highrise::Person do
     it "Can set the value of a custom field via the field method" do
       @fruit_person.set_field_value("Fruit Grape", "Red")
       @fruit_person.field("Fruit Grape").should== "Red"
+    end
+    
+    it "Can set the value of a custom field that wasn't there via the field method, but that was defined (happens on new Person)" do
+      Highrise::SubjectField.should_receive(:find).with(:all).and_return([@subject_field_papaya, @subject_field_blueberry])
+      @fruit_person.set_field_value("Fruit Blueberry", "Purple")
+      @fruit_person.field("Fruit Blueberry").should== "Purple"
+      @fruit_person.attributes["subject_datas"][2].subject_field_id.should == 1
     end
     
   end


### PR DESCRIPTION
When setting a custom field that wasn't set yet, we'll actually need to check whether the custom field exists and then get the field id to set it to the correct field id. It is a bit strange that this is needed as with the company or tag field this isn't needed. But it seems that Highrise can't map the custom field labels to the ids automatically and thus we'll have to manually check which id the custom field is.
