### PR TITLE
Access to a field via method missing

### DIFF
--- a/lib/highrise/person.rb
+++ b/lib/highrise/person.rb
@@ -52,6 +52,27 @@ module Highrise
         end
       }
     end
+
+    def transform_subject_field_label field_label
+      field_label.downcase.tr(' ', '_')
+    end
+    
+    def convert_method_to_field_label method
+      custom_fields = attributes["subject_datas"] ||= []
+      custom_fields.each { |field|
+        method_name_from_field = transform_subject_field_label(field.subject_field_label)
+        return field if method_name_from_field == method
+      }
+      nil
+    end
+    
+    def method_missing(method_symbol, *args)
+      method_name = method_symbol.to_s      
+      field = convert_method_to_field_label(method_name)
+      return field(field.subject_field_label) if field
+      super
+     end    
+    
         
   end
 end

--- a/spec/highrise/person_spec.rb
+++ b/spec/highrise/person_spec.rb
@@ -67,6 +67,14 @@ describe Highrise::Person do
       @fruit_person.field("Fruit Banana").should== "Yellow"
     end
     
+    it "Can get the value of a custom field using a custom method call" do
+      @fruit_person.fruit_grape.should== "Green"
+    end
+    
+    it "Will raise an exception on an unknown field" do
+      expect {@fruit_person.unknown_fruit}.to raise_exception(NoMethodError)
+    end
+    
     it "Can set the value of a custom field via the field method" do
       @fruit_person.set_field_value("Fruit Grape", "Red")
       @fruit_person.field("Fruit Grape").should== "Red"


### PR DESCRIPTION
Use method missing to access custom fields in the same way as 'normal' fields get accessed. This hides the difference between custom fields and others for getting. The pull request is slightly larger than the previous ones, sorry about that.

After this one, we'll do this also for setting, that will be the next pull request.
