### PR TITLE
Added setting field values using method missing

### DIFF
--- a/lib/highrise/person.rb
+++ b/lib/highrise/person.rb
@@ -67,12 +67,19 @@ module Highrise
     end
     
     def method_missing(method_symbol, *args)
-      method_name = method_symbol.to_s      
-      field = convert_method_to_field_label(method_name)
-      return field(field.subject_field_label) if field
+      method_name = method_symbol.to_s
+      
+      if method_name[-1,1] == "="
+        attribute_name = method_name[0...-1]
+        field = convert_method_to_field_label(attribute_name)
+        return set_field_value(field.subject_field_label, args[0]) if field
+        
+        return super if attributes[attribute_name]        
+      else
+        field = convert_method_to_field_label(method_name)
+        return field(field.subject_field_label) if field
+      end
       super
      end    
-    
-        
   end
 end

--- a/spec/highrise/person_spec.rb
+++ b/spec/highrise/person_spec.rb
@@ -80,11 +80,21 @@ describe Highrise::Person do
       @fruit_person.field("Fruit Grape").should== "Red"
     end
     
+    it "Assignment just returns the arguments (like ActiveResource base does)" do
+      (@fruit_person.unknown_fruit = 10).should== 10
+    end
+    
     it "Can set the value of a custom field that wasn't there via the field method, but that was defined (happens on new Person)" do
       Highrise::SubjectField.should_receive(:find).with(:all).and_return([@subject_field_papaya, @subject_field_blueberry])
       @fruit_person.set_field_value("Fruit Blueberry", "Purple")
       @fruit_person.field("Fruit Blueberry").should== "Purple"
       @fruit_person.attributes["subject_datas"][2].subject_field_id.should == 1
+    end
+    
+    it "Can still set and read the usual way of reading attrivutes" do
+      @fruit_person.first_name = "Jacob"
+      @fruit_person.first_name.should== "Jacob"
+    
     end
     
   end


### PR DESCRIPTION
Continuing the same evolution of the code. Method missing can also be used to set custom fields by checking for the = at the end of the method. For this pull request, it only checks for setting the value of existing fields.

Unfortunately, it is more code that I would like because of the parsing and converting of the method name to a field. More to come as this won't work for fields that weren't set before as the conversion of a method name to a field name won't work until the field name is known. The field name won't be known when it isn't read yet (e.g. when creating a new person). So, the next pull request will solve that problem.
