### PR TITLE
Setting fields that weren't set before using method missing

### DIFF
--- a/lib/highrise/person.rb
+++ b/lib/highrise/person.rb
@@ -76,11 +76,12 @@ module Highrise
         
         return super if attributes[attribute_name]        
         
-        SubjectField.find(:all).each { |custom_field| 
+        subject_fields = SubjectField.find(:all)
+        subject_fields.each { |custom_field| 
           if transform_subject_field_label(custom_field.label) == attribute_name
             return attributes["subject_datas"] << new_subject_data(custom_field, args[0])
           end
-        }
+          } unless subject_fields.nil?
       else
         field = convert_method_to_field_label(method_name)
         return field(field.subject_field_label) if field

--- a/spec/highrise/person_spec.rb
+++ b/spec/highrise/person_spec.rb
@@ -86,7 +86,13 @@ describe Highrise::Person do
     end
     
     it "Assignment just returns the arguments (like ActiveResource base does)" do
+      Highrise::SubjectField.should_receive(:find).with(:all).and_return []
       (@fruit_person.unknown_fruit = 10).should== 10
+    end
+    
+    it "Can deal with the find returning nil (which is a bit ugly in the ActiveResource API)" do
+      Highrise::SubjectField.should_receive(:find).with(:all).and_return nil
+      (@fruit_person.unknown_fruit = 10).should== 10      
     end
     
     it "Can set the value of a custom field that wasn't there via the field method, but that was defined (happens on new Person)" do


### PR DESCRIPTION
Ok, this is the last commit related to setting the custom field values in the Person. This allows the user to use method_missing when setting a field that wasn't retrieved before (e.g. a new person). It was similar as the done via the field method, but in this case we do not know the exact name of the field and thus need to iterate over all to find the one.

Got some other changes coming after this, but not in the same methods anymore.
