### PR TITLE
Fix undefined method attributes error in Taggable

### DIFF
--- a/lib/highrise/person.rb
+++ b/lib/highrise/person.rb
@@ -4,10 +4,6 @@ module Highrise
     include Taggable
     include Searchable
 
-    def tags
-      self.attributes.has_key?("tags") ? self.attributes["tags"] : super
-    end
-
     def company
       Company.find(company_id) if company_id
     end

--- a/lib/highrise/taggable.rb
+++ b/lib/highrise/taggable.rb
@@ -1,7 +1,7 @@
 module Highrise
   module Taggable        
     def tags
-      self.get(:tags)
+      self.attributes.has_key?("tags") ? self.attributes["tags"] : self.get(:tags)
     end
 
     def tag!(tag_name)


### PR DESCRIPTION
The recent change to taggable.rb line 12.

```
to_delete = self.tags.find{|tag| tag.attributes['name'] == tag_name} unless tag_name.blank?
```

exposed an inconsistency in the overridden tags method in the Person class and the tags method in the Taggable class. This meant the untag! method raised an error for tags on the Company class. As Taggable is only used in Company and Person it made sense to me to move this to the Taggable class and eliminate the need for overriding the tags method in the Person class. 
The error occurring is as follows:

```
undefined method `attributes' for {"id"=>2237655, "name"=>"Commercial Facility"}:Hash
/app/vendor/bundle/ruby/2.1.0/gems/highrise-3.1.6/lib/highrise/taggable.rb:12
```
