### PR TITLE
Same shortcut as for email addresses, but then for phone_numbers.

### DIFF
--- a/lib/highrise/person.rb
+++ b/lib/highrise/person.rb
@@ -24,6 +24,10 @@ module Highrise
       contact_data.email_addresses.collect { |address| address.address } rescue []
     end
 
+    def phone_numbers
+      contact_data.phone_numbers.collect { |phone_number| phone_number.number } rescue []
+    end
+
     def label
       'Party'
     end

--- a/spec/highrise/person_spec.rb
+++ b/spec/highrise/person_spec.rb
@@ -47,6 +47,24 @@ describe Highrise::Person do
     end
   end
 
+  describe "#phone_numbers" do
+    it "returns an empty array when there is none set" do
+      subject.phone_numbers.should== []
+    end
+
+    it "returns all phone numbers as a string aray" do
+      subject = Highrise::Person.new(:id => 1,
+                                     :contact_data => {
+        :phone_numbers => [{
+          :phone_number => {
+            :number => "123456789"
+          }
+        }]
+      })
+      subject.phone_numbers.should== [ "123456789" ]
+    end
+  end
+
   describe "#tags" do
     before(:each) do
       (@tags = []).tap do


### PR DESCRIPTION
Basically the same as the helper for email_addresses, but then for phone numbers. Next I'd probably want to change the default behavior of some earlier methods, where they earlier returned a nil when not set, it would perhaps be better to return an empty string as it usually makes the code easier when dealing with always a string than dealing with nil. But thats next. This one should be easy.
