### PR TITLE
Changed tags to return ActiveResource objects rather than arrays

### DIFF
--- a/lib/highrise/taggable.rb
+++ b/lib/highrise/taggable.rb
@@ -1,12 +1,17 @@
 module Highrise
-  module Taggable        
+  module Taggable
+
     def tags
-      self.attributes.has_key?("tags") ? self.attributes["tags"] : self.get(:tags)
+      unless self.attributes.has_key?("tags")
+        person_or_company = self.class.find(id)
+        self.attributes["tags"] = person_or_company.attributes.has_key?("tags") ? person_or_company.tags : []
+      end
+      self.attributes["tags"]
     end
 
     def tag!(tag_name)
       self.post(:tags, :name => tag_name) unless tag_name.blank?
-    end    
+    end
 
     def untag!(tag_name)
       to_delete = self.tags.find{|tag| tag.attributes['name'] == tag_name} unless tag_name.blank?

--- a/spec/highrise/person_spec.rb
+++ b/spec/highrise/person_spec.rb
@@ -66,6 +66,32 @@ describe Highrise::Person do
   end
 
   describe "#tags" do
+
+    let(:person_tags) { [
+        {'id' => "414578", 'name' => "cliente"},
+        {'id' => "414580", 'name' => "ged"},
+        {'id' => "414579", 'name' => "iepc"} ]
+    }
+
+    let(:person_john_doe) { { :id => 1, :first_name => "John", :last_name => "Doe" } }
+    let(:person_john_doe_request){ ActiveResource::Request.new(:get, '/people/1.xml', nil, {"Authorization"=>"Bearer OAUTH_TOKEN", "Accept"=>"application/xml"}) }
+    let(:person_john_doe_request_pair){ {person_john_doe_request => ActiveResource::Response.new(person_john_doe.to_xml, 200, {})} }
+
+    it "should return the tags as a Highrise::Tag" do
+      person_john_doe[:tags] = person_tags
+      ActiveResource::HttpMock.respond_to(person_john_doe_request_pair)
+      tags = person_tags.collect {|tag| Highrise::Tag.new(tag)}
+      subject.tags.should == tags
+    end
+
+    it "should return an empty collection when there are no tags" do
+      ActiveResource::HttpMock.respond_to(person_john_doe_request_pair)
+      subject.tags.should == []
+    end
+  end
+
+
+  describe "#tags" do
     before(:each) do
       (@tags = []).tap do
         @tags << {'id' => "414578", 'name' => "cliente"}

--- a/spec/highrise/taggable_behavior.rb
+++ b/spec/highrise/taggable_behavior.rb
@@ -1,6 +1,6 @@
 shared_examples_for "a taggable class" do
   before(:each) do
-    (@tags = []).tap do 
+    (@tags = []).tap do
       @tags << Highrise::Tag.new(:name => "cliente", :id => 414578)
       @tags << Highrise::Tag.new(:name => "ged", :id => 414580)
       @tags << Highrise::Tag.new(:name => "iepc", :id => 414579)
@@ -9,18 +9,13 @@ shared_examples_for "a taggable class" do
 
   it { subject.class.included_modules.should include(Highrise::Taggable) }
 
-  it "#tags" do
-    subject.should_receive(:get).with(:tags).and_return(@tags)
-    subject.tags.should == @tags
-  end
-  
   it "#tag!(tag_name)" do
     subject.should_receive(:post).with(:tags, :name => "client" ).and_return(true)
     subject.tag!("client").should be_true
   end
-  
+
   it "#untag!(tag_name)" do
-    subject.should_receive(:get).with(:tags).and_return(@tags)
+    subject.should_receive(:tags).and_return(@tags)
     subject.should_receive(:delete).with("tags/414578").and_return(true)
     subject.untag!("cliente").should be_true
   end


### PR DESCRIPTION
This pull request is a bit harder than the previous ones (actually delayed this one for a while to think about the specs). The essence is simple. The tags method should return ActiveResource objects (in this case Highrise::Tag) rather than Hash. If it doesn't, then it causes different behavior between dealing with an existing Person or with a new Person. (It was actually quite hard to figure this one out when I got a failure thrown at me when running in production).

Earlier version used get(:tags) which returns an unprocessed Hash. It was hard (stackoverflow said impossible) to change that in a Highrise::Tag object. Now it uses the normal find interface to find 'itself' when the tags attribute do not exist yet and then it will copy the tags from that object into itself. This ensures the objects are of the right type.

Initially, I had only fixed this for Person and removed it out of the Taggable mixin. I was able to generate the implementation to also work for Company (using self.class instead of Highrise::Person) but the specs are more difficult to generalize, so I left them in Person for now.

The pull request is important as without it I can't run my code in production. However, would be open for discussion on solving this in a different way. It works but I'm not incredibly happy with it. (in fact, I'm not happy that Highrise does as if people and companies are the same thing! but that is a different story)