### PR TITLE
Allow `Highrise::Subject` finder methods to accept an optional hash of options

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    highrise (3.2.1)
+    highrise (3.2.2)
       activeresource (>= 3.2.13)
 
 GEM

--- a/lib/highrise/subject.rb
+++ b/lib/highrise/subject.rb
@@ -1,7 +1,8 @@
 module Highrise
   class Subject < Base
-    def notes
-      Note.find_all_across_pages(:from => "/#{self.class.collection_name}/#{id}/notes.xml")
+    def notes(options={})
+      options.merge!(:from => "/#{self.class.collection_name}/#{id}/notes.xml")
+      Note.find_all_across_pages(options)
     end
 
     def add_note(attrs={})
@@ -16,12 +17,14 @@ module Highrise
       Task.create attrs
     end
 
-    def emails
-      Email.find_all_across_pages(:from => "/#{self.class.collection_name}/#{id}/emails.xml")
+    def emails(options={})
+      options.merge!(:from => "/#{self.class.collection_name}/#{id}/emails.xml")
+      Email.find_all_across_pages(options)
     end
 
-    def upcoming_tasks
-      Task.find(:all, :from => "/#{self.class.collection_name}/#{id}/tasks.xml")
+    def upcoming_tasks(options={})
+      options.merge!(:from => "/#{self.class.collection_name}/#{id}/tasks.xml")
+      Task.find(:all, options)
     end
     
     def label

--- a/lib/highrise/version.rb
+++ b/lib/highrise/version.rb
@@ -1,3 +1,3 @@
 module Highrise
-  VERSION = "3.2.1"
+  VERSION = "3.2.2"
 end

--- a/spec/highrise/subject_spec.rb
+++ b/spec/highrise/subject_spec.rb
@@ -29,6 +29,28 @@ describe Highrise::Subject do
     Highrise::Task.should_receive(:find).with(:all, {:from=>"/subjects/1/tasks.xml"}).and_return("tasks")
     subject.upcoming_tasks.should == "tasks"
   end
+
+  context 'finding with since param' do
+    before(:each) do
+      @utc_time_str = "20090114174311"
+    end
+
+    it "#notes" do
+      Highrise::Note.should_receive(:find_all_across_pages).with({:from=>"/subjects/1/notes.xml", :params=>{:since=>@utc_time_str}}).and_return("notes")
+      subject.notes(:params=>{:since=>@utc_time_str}).should == "notes"
+    end
+
+    it "#emails" do
+      Highrise::Email.should_receive(:find_all_across_pages).with({:from=>"/subjects/1/emails.xml", :params=>{:since=>@utc_time_str}}).and_return("emails")
+      subject.emails(:params=>{:since=>@utc_time_str}).should == "emails"
+    end
+
+
+    it "#tasks" do
+      Highrise::Task.should_receive(:find).with(:all, {:from=>"/subjects/1/tasks.xml", :params=>{:since=>@utc_time_str}}).and_return("tasks")
+      subject.upcoming_tasks(:params=>{:since=>@utc_time_str}).should == "tasks"
+    end
+  end
   
   it { subject.label.should == "Subject" }
 end


### PR DESCRIPTION
Allow `Highrise::Subject` finder methods to accept an optional hash of options which are then passed to the appropriate find method. This lets us pass `since` when fetching, for example, a Person's Notes, or a Comapny's emails.

Before:

`person.emails # Have to get all of them`

Now:

`person.emails(:params=>{:since=>"201408051230"})`